### PR TITLE
Aligned Job and Location inputs.  Aligned Job results and Quality of life results

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 </div>
 <!-- <hr>   -->
 <div class="row">
-    <div class="medium-5 large-3 columns">
+    <div class="medium-6  columns">
       <div class="callout secondary">
         <p>Job search results go here</p>
         <!-- <form>
@@ -79,7 +79,7 @@
         </form> -->
       </div>
     </div>
-    <div class="medium-7 large-6 columns">
+    <div class="medium-6 columns">
       <div class="callout secondary">
         <p>Quality of life  results go here</p>
       <!-- <h1>Close Your Eyes and Open Your Mind</h1>

--- a/index.html
+++ b/index.html
@@ -40,14 +40,14 @@
   <div class="callout secondary">
     <form id="skills-form">
       <div class="row">
-        <div class="small-12 columns">
+        <div class="small-6 columns">
           <label>Enter a Job Keyword
             <input type="text" id="input-keyword" placeholder="e.g. Software Engineer">
           </label>
         </div>
-        <div class="small-12 columns">
+        <div class="small-6 columns">
           <label>Pick a Location
-            <input type="text" id="input-location" placeholder="auto complete 25 major cities" autocomplete="on" id ="skils">
+            <input type="text" id="input-location" placeholder="e.g Washington DC" autocomplete="on" id ="skils">
           </label>
           <button type="button" id="search-now" class="button">Search</button>
           <!-- <button type="button" id="teleport" class="button">Test Teleport API</button> -->


### PR DESCRIPTION
## What was the issue

- Both job and location inputs were using  `small-12` which was causing them to be in their own row. 

##  What was fixed

- Aligned both keyword and location inputs by making it `small-6 ` and aligned job results and quality of results by making them `medium -6`.

## Screenshots
![image](https://user-images.githubusercontent.com/61666288/112733136-8cd7c180-8f14-11eb-92bc-554051f20133.png)
